### PR TITLE
[WIP] Regen chunk meshes to remove chunk walls

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -3,7 +3,6 @@ use crate::render::camera::{Camera, PerspectiveCamera};
 
 use core::world::WorldCoordinate;
 use glutin::event::VirtualKeyCode;
-use math::transform::Transform;
 use math::vector::Vector3;
 
 const SPEED: f64 = 20.0;

--- a/src/render/models/chunk_mesh.rs
+++ b/src/render/models/chunk_mesh.rs
@@ -206,7 +206,7 @@ impl ChunkMesh {
         }
     }
 
-    pub fn generate(chunks: &ChunkGroup, block_database: &BlockRegistry) -> ChunkMesh {
+    pub fn generate(chunks: &ChunkGroup, block_database: &BlockRegistry) -> Option<ChunkMesh> {
         let mut mesh = ChunkMesh::default();
 
         for x in 0..CHUNK_WIDTH {
@@ -216,7 +216,7 @@ impl ChunkMesh {
                     let y = y as i16;
                     let z = z as i8;
 
-                    let block = chunks.get_block(x, y, z).unwrap();
+                    let block = chunks.get_block(x, y, z)?;
 
                     if block.id == 0 {
                         continue;
@@ -230,32 +230,32 @@ impl ChunkMesh {
                         };
 
                         let mut block = chunks.get_block(x, y, z - 1);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(FRONT_FACE, position, properties.texture.front);
                         }
 
                         block = chunks.get_block(x, y, z + 1);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(BACK_FACE, position, properties.texture.back);
                         }
 
                         block = chunks.get_block(x - 1, y, z);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(LEFT_FACE, position, properties.texture.left);
                         }
 
                         block = chunks.get_block(x + 1, y, z);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(RIGHT_FACE, position, properties.texture.right);
                         }
 
                         block = chunks.get_block(x, y + 1, z);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(TOP_FACE, position, properties.texture.top);
                         }
 
                         block = chunks.get_block(x, y - 1, z);
-                        if block.is_none() || !block_database.is_opaque(block.unwrap().id) {
+                        if block.is_none() || !block_database.is_opaque(block?.id) {
                             mesh.add_face(BOTTOM_FACE, position, properties.texture.bottom);
                         }
                     }
@@ -267,7 +267,7 @@ impl ChunkMesh {
             mesh.model = Some(Model::new(&mesh.vertices, &mesh.indices));
             mesh.model.as_mut().unwrap().add_vbo(&mesh.vertices_info);
         }
-        mesh
+        Some(mesh)
     }
 }
 

--- a/src/render/models/chunk_mesh.rs
+++ b/src/render/models/chunk_mesh.rs
@@ -170,7 +170,7 @@ const BOTTOM_FACE: Face = Face {
 
 #[derive(Default)]
 pub struct ChunkMesh {
-    model: Option<Model>,
+    model: Model,
     vertices: Vec<Vector3>,
     vertices_info: Vec<GLuint>,
     vertex_count: GLuint,
@@ -199,11 +199,7 @@ impl ChunkMesh {
     }
 
     pub fn index_count(&self) -> usize {
-        if let Some(ref model) = self.model {
-            return model.index_count();
-        } else {
-            return 0;
-        }
+        self.model.index_count()
     }
 
     pub fn generate(chunks: &ChunkGroup, block_database: &BlockRegistry) -> Option<ChunkMesh> {
@@ -264,8 +260,8 @@ impl ChunkMesh {
         }
 
         if !mesh.vertices.is_empty() {
-            mesh.model = Some(Model::new(&mesh.vertices, &mesh.indices));
-            mesh.model.as_mut().unwrap().add_vbo(&mesh.vertices_info);
+            mesh.model = Model::new(&mesh.vertices, &mesh.indices);
+            mesh.model.add_vbo(&mesh.vertices_info);
         }
         Some(mesh)
     }
@@ -273,14 +269,10 @@ impl ChunkMesh {
 
 impl Bindable for ChunkMesh {
     fn bind(&self) {
-        if let Some(ref model) = self.model {
-            model.bind();
-        }
+        self.model.bind();
     }
 
     fn unbind(&self) {
-        if let Some(ref model) = self.model {
-            model.unbind();
-        }
+        self.model.unbind();
     }
 }

--- a/src/render/models/model.rs
+++ b/src/render/models/model.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::ptr;
 use std::vec::Vec;
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Model {
     vao: GLuint,
     vbo_count: GLuint,

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -11,10 +11,11 @@ use core::world::{World, LOAD_DISTANCE};
 use gl::types::GLint;
 use math::container::{Volume, AABB};
 use math::vector::{Vector2, Vector3};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::ptr;
+use std::vec::Vec;
 
 const TEXTURE_RESOLUTION: u32 = 16;
 const FOG: Vector3 = Vector3 {
@@ -151,12 +152,22 @@ impl ChunkRenderer {
 
     pub fn update(&mut self, world: &World) {
         // remove unloaded chunks' meshes
-        self.meshes
-            .retain(|coords, _| world.chunks.contains_key(coords));
+        let new_chunks = world
+            .chunks
+            .keys()
+            .filter(|coords| !self.meshes.contains_key(coords))
+            .collect::<Vec<&ChunkGridCoordinate>>();
+
+        self.meshes.retain(|coords, _| {
+            world.chunks.contains_key(coords)
+                && new_chunks
+                    .iter()
+                    .all(|other| !ChunkGridCoordinate::are_neighbours(coords, other))
+        });
 
         // add new loaded chunk's meshes
-        for coords in world.chunks.keys() {
-            if !self.meshes.contains_key(&coords) {
+        for (coords, _) in world.chunks.iter() {
+            if !self.meshes.contains_key(coords) {
                 let chunk_group = world.get_chunk_group(*coords);
                 self.meshes.insert(
                     *coords,

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -152,11 +152,11 @@ impl ChunkRenderer {
     pub fn update(&mut self, world: &World) {
         // remove unloaded chunk and new chunks neighbour
         self.meshes.retain(|coords, _| {
-            world.chunks.contains_key(coords) && !world.meshes_to_regen.contains(coords)
+            world.chunks.contains_key(coords) && !world.chunk_updates.contains(coords)
         });
 
         // generate missing geometry for loaded chunks
-        for coords in world.meshes_to_regen.iter() {
+        for coords in world.chunk_updates.iter() {
             let chunk_group = world.get_chunk_group(*coords);
             if let Some(mesh) = ChunkMesh::generate(&chunk_group, &self.block_registry) {
                 self.meshes.insert(*coords, mesh);

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -15,7 +15,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::ptr;
-use std::vec::Vec;
 
 const TEXTURE_RESOLUTION: u32 = 16;
 const FOG: Vector3 = Vector3 {

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -151,29 +151,16 @@ impl ChunkRenderer {
     }
 
     pub fn update(&mut self, world: &World) {
-        // find newly generated chunks
-        let new_chunks = world
-            .chunks
-            .keys()
-            .filter(|coords| !self.meshes.contains_key(coords))
-            .collect::<Vec<&ChunkGridCoordinate>>();
-
         // remove unloaded chunk and new chunks neighbour
         self.meshes.retain(|coords, _| {
-            world.chunks.contains_key(coords)
-                && new_chunks
-                    .iter()
-                    .all(|other| !ChunkGridCoordinate::are_neighbours(coords, other))
+            world.chunks.contains_key(coords) && !world.meshes_to_regen.contains(coords)
         });
 
         // generate missing geometry for loaded chunks
-        for (coords, _) in world.chunks.iter() {
-            if !self.meshes.contains_key(coords) {
-                let chunk_group = world.get_chunk_group(*coords);
-                self.meshes.insert(
-                    *coords,
-                    ChunkMesh::generate(&chunk_group, &self.block_registry),
-                );
+        for coords in world.meshes_to_regen.iter() {
+            let chunk_group = world.get_chunk_group(*coords);
+            if let Some(mesh) = ChunkMesh::generate(&chunk_group, &self.block_registry) {
+                self.meshes.insert(*coords, mesh);
             }
         }
     }

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -11,7 +11,7 @@ use core::world::{World, LOAD_DISTANCE};
 use gl::types::GLint;
 use math::container::{Volume, AABB};
 use math::vector::{Vector2, Vector3};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::ptr;
@@ -151,13 +151,14 @@ impl ChunkRenderer {
     }
 
     pub fn update(&mut self, world: &World) {
-        // remove unloaded chunks' meshes
+        // find newly generated chunks
         let new_chunks = world
             .chunks
             .keys()
             .filter(|coords| !self.meshes.contains_key(coords))
             .collect::<Vec<&ChunkGridCoordinate>>();
 
+        // remove unloaded chunk and new chunks neighbour
         self.meshes.retain(|coords, _| {
             world.chunks.contains_key(coords)
                 && new_chunks
@@ -165,7 +166,7 @@ impl ChunkRenderer {
                     .all(|other| !ChunkGridCoordinate::are_neighbours(coords, other))
         });
 
-        // add new loaded chunk's meshes
+        // generate missing geometry for loaded chunks
         for (coords, _) in world.chunks.iter() {
             if !self.meshes.contains_key(coords) {
                 let chunk_group = world.get_chunk_group(*coords);

--- a/src/render/renderer/chunk_renderer.rs
+++ b/src/render/renderer/chunk_renderer.rs
@@ -157,7 +157,7 @@ impl ChunkRenderer {
 
         // generate missing geometry for loaded chunks
         for coords in world.chunk_updates.iter() {
-            let chunk_group = world.get_chunk_group(*coords);
+            let chunk_group = world.chunk_group(*coords);
             if let Some(mesh) = ChunkMesh::generate(&chunk_group, &self.block_registry) {
                 self.meshes.insert(*coords, mesh);
             }


### PR DESCRIPTION
This works although it regenerate the mesh data 4 to 5 times per chunk and has a O(n^2) check that slows the fps down more than simply rendering the world borders

an alternate solution would be to hold a list of chunk updates and the renderer could consume these to regenerate the chunk without a complex check. this solution would also implement the logic for updating chunk on placing and removal of blocks.

this is trying to solve #17 